### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,8 @@ As of September 2017, this project is deprecated.
  
  &nbsp;
 
-[![Downloads](https://img.shields.io/pypi/dm/py-cpuutilization.svg
-[![Latest Version](https://img.shields.io/pypi/v/py-cpuutilization.svg
-[![License](https://img.shields.io/pypi/l/py-cpuutilization.svg
+[![Latest Version](https://img.shields.io/pypi/v/py-cpuutilization.svg)](https://pypi.python.org/pypi/py-cpuutilization/)
+[![License](https://img.shields.io/pypi/l/py-cpuutilization.svg)](https://pypi.python.org/pypi/py-cpuutilization/)
 
 A module for getting the CPU utilization on any OS with Python 2 & 3
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ As of September 2017, this project is deprecated.
  
  &nbsp;
 
-[![Downloads](https://pypip.in/d/py-cpuutilization/badge.png?period=month)](https://pypi.python.org/pypi/py-cpuutilization/)
-[![Latest Version](https://pypip.in/v/py-cpuutilization/badge.png)](https://pypi.python.org/pypi/py-cpuutilization/)
-[![License](https://pypip.in/license/py-cpuutilization/badge.png)](https://pypi.python.org/pypi/py-cpuutilization/)
+[![Downloads](https://img.shields.io/pypi/dm/py-cpuutilization.svg
+[![Latest Version](https://img.shields.io/pypi/v/py-cpuutilization.svg
+[![License](https://img.shields.io/pypi/l/py-cpuutilization.svg
 
 A module for getting the CPU utilization on any OS with Python 2 & 3
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20py-cpuutilization))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `py-cpuutilization`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.